### PR TITLE
use opername instead of nickname when logging mask changes

### DIFF
--- a/make-database.sql
+++ b/make-database.sql
@@ -11,7 +11,8 @@ CREATE TABLE masks (
 );
 CREATE TABLE changes (
     mask_id INTEGER NOT NULL,
-    by      TEXT NOT NULL,
+    by_nick TEXT NOT NULL,
+    by_oper TEXT,
     time    INTEGER NOT NULL,
     change  TEXT NOT NULL
 );

--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -1,4 +1,4 @@
-import asyncio, re
+import asyncio, re, traceback
 from collections import deque, OrderedDict
 from datetime    import datetime
 from time        import monotonic

--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -6,12 +6,11 @@ from typing      import Deque, Dict, List, Optional, Tuple
 from typing      import OrderedDict as TOrderedDict
 
 
-from irctokens import build, Line
+from irctokens import build, Line, Hostmask
 from ircrobots import Bot as BaseBot
 from ircrobots import Server as BaseServer
 
 from ircstates.numerics   import *
-from ircstates            import Hostmask
 from ircrobots.matching   import Response, ANY, Folded, SELF
 from ircchallenge         import Challenge
 

--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -350,7 +350,7 @@ class Server(BaseServer):
             opername = None if opername == "<grant>" else opername
             attrib  = f"cmd_{command}"
             if hasattr(self, attrib):
-                outs = await getattr(self, attrib)(opername, who._source, args)
+                outs = await getattr(self, attrib)(opername, str(who), args)
                 for out in outs:
                     await self.send(build("NOTICE", [who.nickname, out]))
             else:

--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -288,7 +288,7 @@ class Server(BaseServer):
             await self.send(build("PRIVMSG", [self._config.channel, out]))
 
             cmd, _, args = line.params[1].partition(" ")
-            await self.cmd(line.hostmask.nickname, cmd.lower(), args)
+            await self.cmd(line.hostmask, cmd.lower(), args)
 
         else:
 

--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -103,7 +103,6 @@ class Server(BaseServer):
         # return the oper name or nothing
         if whois_line.command == RPL_WHOISOPERATOR:
             match = re.search(r"^is opered as (\S+)(?:,|$)", whois_line.params[2])
-            print(match)
             if match is not None:
                 return match.group(1)
         return None

--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -11,7 +11,7 @@ from ircrobots import Bot as BaseBot
 from ircrobots import Server as BaseServer
 
 from ircstates.numerics   import *
-from ircstates            import User
+from ircstates            import Hostmask
 from ircrobots.matching   import Response, ANY, Folded, SELF
 from ircchallenge         import Challenge
 from ircrobots.formatting import strip as format_strip
@@ -253,7 +253,7 @@ class Server(BaseServer):
                     self._users[new_nick] = user
 
     async def cmd(self,
-            who:     User,
+            who:     Hostmask,
             command: str,
             args:    str):
 
@@ -385,7 +385,6 @@ class Server(BaseServer):
                     await self._database.masks.set_type(
                         nick, oper, mask_id, mask_type
                     )
-                    
                     if oper is not None:
                         who = f"{nick} ({oper})"
                     else:


### PR DESCRIPTION
this is achieved by sending the opername instead of the nickname for the who parameter. per #7.