### PR TITLE
excluded masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ delimiters on `/<regex>/` can be any non-alphanumeric character, e.g. `,<regex>,
 
 ### SETMASK
 ```
-/msg bismite setmask <id> <WARN|LETHAL|DLETHAL>
+/msg bismite setmask <id> WARN|LETHAL|DLETHAL|EXCLUDE
 ```
 
 ### TOGGLEMASK
@@ -65,3 +65,8 @@ Same as warn, but also k-lines the user.
 ### DLETHAL
 
 Same as lethal, but the k-line is delayed a bit.
+
+### EXCLUDE
+
+Same as `WARN`, but is seen as more "important" than other mask types, and
+will thus prevent people matching it from matching e.g. `LETHAL` masks.

--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -123,7 +123,6 @@ class Server(BaseServer):
 
             # get all (mask, details) for matched IDs
             matches = [await self._database.masks.get(i) for i in match_ids]
-            print(matches)
 
             # sort by mask type, descending
             # this should order: exclude, dlethal, lethal, warn

--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -94,7 +94,7 @@ class Server(BaseServer):
             nick:  str,
             user:  User,
             event: Event
-            ) -> Optional[int]:
+            ) -> List[int]:
 
         references = [f"{nick}!{user.user}@{user.host} {user.real}"]
         if (user.ip is not None and
@@ -103,20 +103,33 @@ class Server(BaseServer):
             # also match against that IP
             references.append(f"{nick}!{user.user}@{user.ip} {user.real}")
 
+        matches: List[int] = []
         for mask_id, (pattern, flags) in self._compiled_masks.items():
             for ref in references:
                 if ((not event == Event.NICK or "N" in flags) and
                         pattern.search(ref)):
-                    return mask_id
+                    matches.append(mask_id)
+        return matches
 
     async def mask_check(self,
             nick:  str,
             user:  User,
             event: Event):
 
-        mask_id = await self._mask_match(nick, user, event)
-        if mask_id is not None:
-            _, d = await self._database.masks.get(mask_id)
+        match_ids = await self._mask_match(nick, user, event)
+        if match_ids:
+            for match_id in match_ids:
+                await self._database.masks.hit(match_id)
+
+            # get all (mask, details) for matched IDs
+            matches = [await self._database.masks.get(i) for i in match_ids]
+            print(matches)
+
+            # sort by mask type, descending
+            # this should order: exclude, dlethal, lethal, warn
+            matches.sort(key=lambda m: m[1].type, reverse=True)
+
+            mask, d = matches[0]
 
             ident  = user.user
             # if the user doesn't have identd, bin the whole host
@@ -145,11 +158,10 @@ class Server(BaseServer):
             elif d.type == MaskType.DLETHAL:
                 self.delayed_send.append((monotonic(), ban))
 
-            await self._database.masks.hit(mask_id)
             await self.send(build("PRIVMSG", [
                 self._config.channel,
                 (
-                    f"MASK: {d.type.name} mask {mask_id} "
+                    f"MASK: {d.type.name} mask {match_id} "
                     f"{nick}!{user.user}@{user.host} {user.real}"
                 )
             ]))

--- a/maskwatch-bot/common.py
+++ b/maskwatch-bot/common.py
@@ -16,9 +16,10 @@ class MaskType(IntEnum):
     WARN    = 1
     LETHAL  = 2
     DLETHAL = 3
+    EXCLUDE = 4
 
     def __contains__(self, name: str):
-        return name in {"LETHAL", "WARN", "DLETHAL"}
+        return name in {"WARN", "LETHAL", "DLETHAL", "EXCLUDE"}
 
 class Event(Enum):
     CONNECT = 1

--- a/maskwatch-bot/common.py
+++ b/maskwatch-bot/common.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from enum        import Enum
+from enum        import Enum, IntEnum
 from typing      import Pattern, Optional, Tuple
 
 @dataclass
@@ -12,9 +12,9 @@ class User(object):
 
     connected: bool = True
 
-class MaskType(Enum):
-    LETHAL  = 1
-    WARN    = 2
+class MaskType(IntEnum):
+    WARN    = 1
+    LETHAL  = 2
     DLETHAL = 3
 
     def __contains__(self, name: str):


### PR DESCRIPTION
closes #5 

`WARN` and `EXCLUDE` are functionally identical, except the latter is seen as more important than any other masks; lethal will override warn, exclude will override lethal.