### PR TITLE
if no explicit oper reason provided, assume whole reason is oper reason

### DIFF
--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -317,6 +317,11 @@ class Server(BaseServer):
                 else:
                     reason = args[end:].strip()
                     if reason:
+                        # if there's no explicit oper reason, assume this
+                        # is an oper reason. safer than assuming public.
+                        if not "|" in reason:
+                            reason = f"|{reason}"
+
                         mask_id = await self._database.masks.add(
                             nick, mask, reason
                         )


### PR DESCRIPTION
closes #21 