### PR TITLE
add TESTMASK command

### DIFF
--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -13,12 +13,13 @@ from ircrobots import Server as BaseServer
 from ircstates.numerics   import *
 from ircrobots.matching   import Response, ANY, Folded, SELF
 from ircchallenge         import Challenge
-from ircrobots.formatting import strip as format_strip
 
-from .common   import Event, MaskType, User, mask_compile, mask_find
-from .common   import to_pretty_time, FLAGS_INCONEQUENTIAL
 from .config   import Config
 from .database import Database
+
+from .common   import Event, MaskType, User, to_pretty_time
+from .common   import mask_compile, mask_find, mask_token
+from .common   import FLAGS_INCONEQUENTIAL
 
 # not in ircstates yet...
 RPL_RSACHALLENGE2      = "740"
@@ -380,21 +381,13 @@ class Server(BaseServer):
         return outs
 
     async def cmd_addmask(self, nick: str, args: str):
-        args = args.lstrip()
-        if not args:
-            return ["no args provided"]
-
-        end = mask_find(args)
-        if end < 1:
-            return ["unterminated regexen"]
-
-        mask = format_strip(args[:end])
         try:
+            mask, args   = mask_token(args)
             cmask, flags = mask_compile(mask)
         except re.error as e:
             return [f"regex error: {str(e)}"]
         else:
-            reason = args[end:].strip()
+            reason = args
             if not reason:
                 return ["please provide a reason"]
 
@@ -516,19 +509,11 @@ class Server(BaseServer):
         return outs or ["no reason templates"]
 
     async def cmd_testmask(self, nick: str, args: str):
-        args = args.lstrip()
-        if not args:
-            return ["no args provided"]
-
-        end = mask_find(args)
-        if end < 1:
-            return ["unterminated regexen"]
-
-        mask = format_strip(args[:end])
         try:
+            mask, _      = mask_token(args)
             cmask, flags = mask_compile(mask)
-        except re.error as e:
-            return [f"regex error: {str(e)}"]
+        except Exception as e:
+            return [f"failed to add mask: {str(e)}"]
 
         samples = 0
         matches: List[str] = []

--- a/maskwatch-bot/common.py
+++ b/maskwatch-bot/common.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from enum        import Enum, IntEnum
 from typing      import Pattern, Optional, Set, Tuple
 
+from ircrobots.formatting import strip as format_strip
+
 @dataclass
 class User(object):
     user: str
@@ -37,16 +39,16 @@ class MaskDetails(object):
 
 FLAGS_INCONEQUENTIAL = set("i")
 def mask_compile(
-        pattern: str
+        mask:  str
         ) -> Tuple[Pattern, Set[str]]:
-    p, sflags = pattern.rsplit(pattern[0], 1)
-    pattern   = p[1:]
+
+    mask, sflags = mask.rsplit(mask[0], 1)
 
     rflags = 0
     if "i" in sflags:
         rflags |= re.I
 
-    return re.compile(pattern, rflags), set(sflags)
+    return re.compile(mask[1:], rflags), set(sflags)
 
 def _find_unescaped(s: str, c: str):
     i = 0
@@ -74,6 +76,21 @@ def mask_find(s: str):
                 return end
     else:
         raise ValueError("pattern delim not found")
+
+def mask_token(
+        input: str
+        ) -> Tuple[Pattern, Set[str], str]:
+
+    input = input.lstrip()
+    if not input:
+        raise ValueError("no input provided")
+
+    end = mask_find(input)
+    if end < 1:
+        raise ValueError("unterminated regexen")
+
+    mask = format_strip(input[:end])
+    return mask, input[end+1:]
 
 SECONDS_MINUTES = 60
 SECONDS_HOURS   = SECONDS_MINUTES*60


### PR DESCRIPTION
closes #34. I one-upped the description there, and it'll now show you the oldest 10 masks that are hit, to help you tweak it to avoid innocents.

draft because I'd like to refactor out mask lexing, compiling and testing so `ADDMASK` and `TESTMASK` don't need to have duplicated code.