### PR TITLE
/N masks should also match on connect

### DIFF
--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -133,8 +133,8 @@ class Server(BaseServer):
         else:
             uflags.add("A")
 
-        if event == Event.NICK:
-            uflags.add("N")
+        if event == Event.CONNECT:
+            uflags.add("n")
 
         references = [f"{nick}!{user.user}@{user.host} {user.real}"]
         if user.ip is not None:

--- a/maskwatch-bot/common.py
+++ b/maskwatch-bot/common.py
@@ -48,7 +48,17 @@ def mask_compile(
     if "i" in sflags:
         rflags |= re.I
 
-    return re.compile(mask[1:], rflags), set(sflags)
+    flags = set(sflags)
+
+    # flags should be expressed as "only match x" rather than "also match x"
+    # "N" means "also match nick changes" but "n" means "only match connect"
+    # so if we have no "N", we add "n"
+    if not "N" in flags:
+        flags.add("n")
+    else:
+        flags.remove("N")
+
+    return re.compile(mask[1:], rflags), flags
 
 def _find_unescaped(s: str, c: str):
     i = 0


### PR DESCRIPTION
this is a bit hacky but we can change it in the future. the comment in the code should explain how/why this works, but an additional note is the `flags` returned by `mask_compile` are never presented to the user, so we can tweak them like this as much as we want