### PR TITLE
use the actually matched mask id

### DIFF
--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -174,14 +174,15 @@ class Server(BaseServer):
                 await self._database.masks.hit(match_id)
 
             # get all (mask, details) for matched IDs
-            matches = [await self._database.masks.get(i) for i in match_ids]
-            types   = {d.type for m, d in matches}
+            matches = [(i, await self._database.masks.get(i)) \
+                for i in match_ids]
+            types   = {d.type for i, (m, d) in matches}
 
             # sort by mask type, descending
             # this should order: exclude, dlethal, lethal, warn
-            matches.sort(key=lambda m: m[1].type, reverse=True)
+            matches.sort(key=lambda m: m[1][1].type, reverse=True)
 
-            mask, d = matches[0]
+            mask_id, (mask, d) = matches[0]
 
             ident  = user.user
             # if the user doesn't have identd, bin the whole host
@@ -219,7 +220,7 @@ class Server(BaseServer):
                 await self.send(build("PRIVMSG", [
                     self._config.channel,
                     (
-                        f"MASK: {d.type.name} mask {match_id} "
+                        f"MASK: {d.type.name} mask {mask_id} "
                         f"{nick}!{user.user}@{user.host} {user.real}"
                     )
                 ]))


### PR DESCRIPTION
`match_id` wasn't ever intentionally being defined, so it was left defined as the last thing iterated through here
https://github.com/Libera-Chat/maskwatch-bot/blob/938fc875a6d1b629566e25c5741eb0d4cdb99804/maskwatch-bot/__init__.py#L173-L174
which meant it would be wrong if more than 1 mask was matched but we didn't pick the last one to take precedence