### PR TITLE
remove FLAGS_INCONSEQUENTIAL at the point of mask compilation

### DIFF
--- a/maskwatch-bot/__init__.py
+++ b/maskwatch-bot/__init__.py
@@ -19,7 +19,6 @@ from .database import Database
 
 from .common   import Event, MaskType, User, to_pretty_time
 from .common   import mask_compile, mask_find, mask_token
-from .common   import FLAGS_INCONEQUENTIAL
 
 # not in ircstates yet...
 RPL_RSACHALLENGE2      = "740"
@@ -154,8 +153,7 @@ class Server(BaseServer):
 
         matches: List[int] = []
         for mask_id, (pattern, flags) in self._compiled_masks.items():
-            nflags  = flags - uflags
-            nflags -= FLAGS_INCONEQUENTIAL
+            nflags = flags - uflags
             for ref in references:
                 # which flags does the pattern want that we've not got?
                 if not nflags and pattern.search(ref):
@@ -422,8 +420,7 @@ class Server(BaseServer):
                 samples += 1
                 recent_masks, uflags = self._recent_masks[i]
                 for recent_mask in recent_masks:
-                    nflags  = flags - uflags
-                    nflags -= FLAGS_INCONEQUENTIAL
+                    nflags = flags - uflags
                     if not nflags and cmask.search(recent_mask):
                         matches += 1
                         # only breaks one level of `for`
@@ -540,8 +537,7 @@ class Server(BaseServer):
             samples += 1
             recent_masks, uflags = self._recent_masks[i]
             for recent_mask in recent_masks:
-                nflags  = flags - uflags
-                nflags -= FLAGS_INCONEQUENTIAL
+                nflags = flags - uflags
                 if not nflags and cmask.search(recent_mask):
                     matches.append(recent_mask)
                     # only breaks one level of `for`

--- a/maskwatch-bot/common.py
+++ b/maskwatch-bot/common.py
@@ -48,7 +48,8 @@ def mask_compile(
     if "i" in sflags:
         rflags |= re.I
 
-    flags = set(sflags)
+    flags  = set(sflags)
+    flags -= FLAGS_INCONEQUENTIAL
 
     # flags should be expressed as "only match x" rather than "also match x"
     # "N" means "also match nick changes" but "n" means "only match connect"

--- a/maskwatch-bot/common.py
+++ b/maskwatch-bot/common.py
@@ -37,7 +37,7 @@ class MaskDetails(object):
     last_hit: Optional[int]
 
 
-FLAGS_INCONEQUENTIAL = set("i")
+FLAGS_INCONSEQUENTIAL = set("i")
 def mask_compile(
         mask:  str
         ) -> Tuple[Pattern, Set[str]]:
@@ -49,7 +49,7 @@ def mask_compile(
         rflags |= re.I
 
     flags  = set(sflags)
-    flags -= FLAGS_INCONEQUENTIAL
+    flags -= FLAGS_INCONSEQUENTIAL
 
     # flags should be expressed as "only match x" rather than "also match x"
     # "N" means "also match nick changes" but "n" means "only match connect"


### PR DESCRIPTION
because we never present `mask_compile`'s `flags` to end users, we are free to mangle them to remove stuff that isn't needed later